### PR TITLE
feat: Add initial structure for web GUI with FastAPI backend and Reac…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,5 +29,13 @@ use_repo(crate, "crates")
 
 # Python toolchain configuration
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.12")
+python.toolchain(python_version = "3.12") # Consider matching this with your project's Python version if different
 use_repo(python, "python_versions")
+
+# Setup pip to parse requirements_lock.txt
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse_requirements(
+    name = "pip_deps", # This creates a repository named @pip_deps
+    requirements_lock = "//:requirements_lock.txt",
+)
+use_repo(pip, "pip_deps")

--- a/gui/BUILD.bazel
+++ b/gui/BUILD.bazel
@@ -1,0 +1,23 @@
+# This BUILD file serves as the main entry point for GUI-related targets.
+
+# Alias for the backend server, making it easier to run from this package level.
+# e.g., `bazel run //gui:server`
+alias(
+    name = "server",
+    actual = "//gui/backend:bifrost_gui_server",
+    visibility = ["//visibility:public"], # Or restrict as needed
+)
+
+# Grouping the frontend sources.
+# This could be used later if the server is configured to serve these files,
+# or if another process needs to consume them.
+filegroup(
+    name = "frontend_assets_sources",
+    srcs = ["//gui/frontend:bifrost_gui_frontend_sources"],
+    visibility = ["//visibility:public"], # Or restrict as needed
+)
+
+# Future: This BUILD file could also contain:
+# - Rules to package the entire GUI application (backend + compiled frontend assets).
+# - Shared libraries or utilities used by both backend and frontend (if applicable, e.g. protobuf definitions).
+# - Test suites that cover integration between frontend and backend.

--- a/gui/backend/BUILD.bazel
+++ b/gui/backend/BUILD.bazel
@@ -1,0 +1,35 @@
+# This BUILD file assumes that Python dependencies like fastapi and uvicorn
+# are made available to Bazel through pip.parse_requirements in MODULE.bazel.
+#
+# Example configuration in MODULE.bazel:
+# ```
+# pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+# pip.parse_requirements(
+#     name = "pip_deps", # This defines the repository name @pip_deps
+#     requirements_lock = "//:requirements_lock.txt",
+# )
+# use_repo(pip, "pip_deps")
+# ```
+# Dependencies can then be referenced as "@pip_deps//fastapi", "@pip_deps//uvicorn".
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "bifrost_gui_server",
+    srcs = ["main.py"],
+    # When this binary is run (e.g., "bazel run //gui/backend:bifrost_gui_server"),
+    # the __main__ block in main.py will be executed, starting the uvicorn server.
+    main = "main.py",
+    deps = [
+        # These targets are expected to be provided by the pip.parse_requirements
+        # rule in your MODULE.bazel file, using a repository named "pip_deps".
+        # If you use a different name for the parsed pip dependencies repo,
+        # update these paths accordingly.
+        "@pip_deps//fastapi",
+        "@pip_deps//uvicorn",
+        # Add other direct dependencies of main.py here if any.
+    ],
+    # This visibility allows other parts of your Bazel project (like a main //gui:BUILD.bazel)
+    # to depend on this server.
+    visibility = ["//gui:__pkg__"],
+)

--- a/gui/backend/main.py
+++ b/gui/backend/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello from Bifrost GUI Backend"}
+
+@app.get("/api/status")
+async def get_status():
+    return {"status": "running", "version": "0.1.0"}
+
+# To run this application (from the gui/backend directory):
+# uvicorn main:app --reload
+#
+# Then open your browser to http://127.0.0.1:8000/
+# Or for the status endpoint: http://127.0.0.1:8000/api/status
+
+if __name__ == "__main__":
+    import uvicorn
+    # This allows running the app with "python main.py"
+    # For Bazel's py_binary, this __main__ block will be executed.
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/gui/frontend/BUILD.bazel
+++ b/gui/frontend/BUILD.bazel
@@ -1,0 +1,45 @@
+# This BUILD file is a placeholder for the React frontend.
+# A full Bazel setup for a React application would typically involve:
+# 1. Adding `rules_nodejs` to your MODULE.bazel or WORKSPACE.
+# 2. Using `npm_install` or `yarn_install` rules to manage node_modules.
+# 3. Using rules like `ts_project` (for TypeScript), `webpack_bundle`, or
+#    custom genrules to compile/bundle the React application.
+#
+# For now, this filegroup simply makes Bazel aware of the frontend source files.
+
+filegroup(
+    name = "bifrost_gui_frontend_sources",
+    srcs = glob([
+        "*.html",
+        "*.json",
+        "src/**/*.js",
+        "src/**/*.css",
+        # Add other file types like .ts, .tsx, .svg, .png if they exist
+    ]),
+    visibility = ["//gui:__pkg__"],
+)
+
+# TODO: Replace the filegroup above with actual Bazel rules for building
+# the React application when a Node.js toolchain and rules_nodejs are configured.
+# Example (conceptual, depends on rules_nodejs setup):
+#
+# load("@npm//:defs.bzl", "npm_link_all_packages")
+# load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+#
+# npm_link_all_packages(name = "node_modules")
+#
+# nodejs_binary(
+#     name = "build_script",
+#     data = [
+#         ":node_modules",
+#         "package.json",
+#         "//:bazel_version", # example dependency
+#         # ... other dependencies
+#     ] + glob(["src/**"]) + glob(["public/**"]),
+#     entry_point = ":node_modules/react-scripts/bin/react-scripts.js",
+#     args = ["build"],
+#     output_dir = True,
+# )
+#
+# This is a simplified example; actual implementation can be more complex.
+# Using Vite or another modern bundler might also be preferable.

--- a/gui/frontend/index.html
+++ b/gui/frontend/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Bifrost GUI - Web site created using create-react-app"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>Bifrost GUI</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/gui/frontend/package.json
+++ b/gui/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "bifrost-gui-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "echo \"TODO: Implement start script with a dev server like Vite or CRA\"",
+    "build": "echo \"TODO: Implement build script with a bundler like Vite or Webpack\"",
+    "test": "echo \"TODO: Implement test script\""
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/gui/frontend/src/App.css
+++ b/gui/frontend/src/App.css
@@ -1,0 +1,18 @@
+.App {
+  text-align: center;
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}

--- a/gui/frontend/src/App.js
+++ b/gui/frontend/src/App.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import './App.css';
+
+function App() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1>Hello from Bifrost React GUI!</h1>
+        <p>This is a placeholder for the Bifrost user interface.</p>
+        <p>Backend status should eventually be displayed here.</p>
+      </header>
+    </div>
+  );
+}
+
+export default App;

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/gui/frontend/src/index.js
+++ b/gui/frontend/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css'; // We'll create this for basic body styling
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -9,3 +9,5 @@ pytest>=8.0
 pytest-asyncio>=0.23
 mypy>=1.8
 ruff>=0.1.9
+fastapi>=0.100
+uvicorn[standard]>=0.20


### PR DESCRIPTION
…t frontend placeholder

- Sets up a basic FastAPI application in gui/backend/
- Includes Bazel build rules (py_binary) for the backend server.
- Updates requirements_lock.txt and MODULE.bazel to handle Python dependencies (fastapi, uvicorn) via pip.parse_requirements.
- Creates a placeholder React application structure in gui/frontend/.
- Includes a placeholder Bazel build rule (filegroup) for frontend sources.
- Adds a main gui/BUILD.bazel to aggregate GUI targets.